### PR TITLE
Add Kubernetes OpenTracing support topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ This project is about changing this by developing and applying a tool to each Ku
 * Mentors(s): Dr. Stefan Schimanski (@sttts)
 * Issue: https://github.com/kubernetes/kubernetes/issues/56348 and https://github.com/kubernetes/kubernetes/pull/58064
 
+#### OpenTracing support
+In order to troubleshoot Kubernetes latencies it would be great to have tracing support. Metrics are great for alerting, to know if something is wrong, but by design are not meant to trace the execution of single requests. Tracing support would allow troubleshooting high latency requests in order to find performance improvement opportunities more easily and quickly.
+This project involves evaluating tracing solutions as well as implementing support for the Kubernetes API handlers.
+* Recommended skills: Kubernetes, OpenTracing
+* Mentor(s): Dr. Stefan Schimanski (@sttts), Frederic Branczyk (@brancz)
+* Issue: https://github.com/kubernetes/kubernetes/issues/26507
+
 ### Containerd
 
 #### KataContainers support for containerd/cri-containerd 


### PR DESCRIPTION
For the reasons stated in the proposal, it would be nice to have tracing support in Kubernetes. As a start we could do the API handlers, and extend this to the entire code base gradually.

@caniszczyk @idvoretskyi @nikhita @sttts 