### PR TITLE
Add note about using only public channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ Please, submit your ideas below using the [template](/PROJECT_IDEA_TEMPLATE.md).
 
 ### Kubernetes
 
-Please visit the [Kubernetes GSoC page](https://git.k8s.io/community/mentoring/google-summer-of-code.md) for general information. For any questions or comments, please reach out to us on the #gsoc-apps channel on the [Kubernetes slack](http://slack.k8s.io/).
+Please visit the [Kubernetes GSoC page](https://git.k8s.io/community/mentoring/google-summer-of-code.md) for general information.
+
+**Communication**:
+
+For any questions or comments, please reach out to us on the #gsoc-apps channel on the [Kubernetes slack](http://slack.k8s.io/).
+Please don't use DMs or personal emails unless strictly necessary.
 
 #### Integrate kube-batch with pytorch-operator/mxnet-operator
 


### PR DESCRIPTION
Lots of mentors mentioned that they are getting an overwhelming amount of personal emails and DMs.

I'm not sure if I can say this for other CNCF projects, but for Kubernetes, we'd like to limit to using public channels unless necessary otherwise or if the mentor decides that they want to discuss things in a private channel.

Discussions in open source should be in the open and **DMs just don't scale**. :)
