### PR TITLE
Add CoreDNS project for autoscaling CoreDNS nodes

### DIFF
--- a/communitybridge/README.md
+++ b/communitybridge/README.md
@@ -186,6 +186,19 @@ details.
 - Relevant Issues: https://thanos.io/proposals/201901-read-write-operations-bucket.md/ https://github.com/thanos-io/thanos/issues/1528
 - Potential Mentors: Bartek Plotka (@bwplotka)
 
+### CoreDNS
+
+#### Autoscaling CoreDNS Nodes on Kubernetes Clusters Through Exposed Metrics
+
+- Description: [CoreDNS](https://github.com/coredns/coredns) is Kubernetes' default DNS server for service discovery. As service discovery with DNS is the (often overlooked) critical piece for clusters, it is important to maintain enough capacity for serving the cluster-wide service discovery. CoreDNS already have a `metrics` plugin with metrics information exposed. In this project, the student will work on the following tasks:
+  - Write metrics scraping method to extract the metrics from exposed CoreDNS metrics plugin.
+  - Develop a method in transforming collected metrics into desired capacity for CoreDNS nodes.
+  - Implement a routine to interact with Kubernetes API to autoscaling CoreDNS node with designed capacity.
+- Bonus Task: Use machine learning algorithm for transforming metrics to above mentioned designed capacity. We will provide a start algorithm to help student getting started with machine learning, if student is willing to take this bonus task.
+- Recommended Skills: Golang and DNS for this project, basic machine learning for bonus task.
+- Mentor(s): Yong Tang @yongtang
+- Issue: https://github.com/coredns/coredns/issues/3541
+
 ## 2019
 
 In 2019, CNCF was participating in the Community Bridge, sponsoring three mentees to work on Kubernetes and CoreDNS projects during the foundations’ pilot stage.


### PR DESCRIPTION
This PR adds a CoreDNS project for autoscaling CoreDNS nodes. A bonus task
is to use machine learning for metrics to capacity transformation. We will
provide a starter machine learning algorithm to help getting started if
needed.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>